### PR TITLE
add support to update datasources

### DIFF
--- a/Modules/PowerBIPS/PowerBIPS.psd1
+++ b/Modules/PowerBIPS/PowerBIPS.psd1
@@ -62,7 +62,7 @@ FunctionsToExport = @(
 	"Get-PBIAuthToken"
 	, "Set-PBIGroup", "Get-PBIGroup", "Get-PBIGroupUsers", "New-PBIGroup", "New-PBIGroupUser"
 	, "Out-PowerBI"	
-    , "Get-PBIDataSet", "Test-PBIDataSet", "New-PBIDataSet", "Update-PBIDataset", "Get-PBIDatasetRefreshHistory"
+    , "Get-PBIDataSet", "Test-PBIDataSet", "New-PBIDataSet", "Update-PBIDataset", "Get-PBIDatasetRefreshHistory", "Update-PBIDatasetDatasources"
     , "Get-PBIDatasetParameters", "Set-PBIDatasetParameters"
 	, "Add-PBITableRows", "Clear-PBITableRows", "Update-PBITableSchema"	
 	, "Get-PBIImports", "Import-PBIFile"


### PR DESCRIPTION
So far this module has not been able to update datasource to target another server. This is useful for me.
I added some more detailed error handling because it is not obvious that a 404 does not mean that the URL does not exist but can as well mean that the selector does no match any current data source.

Feel free to make any changes to adjust for your naming conventions.