### PR TITLE
Fix Import-PBIFile and add Get-PBIGroupDatasets to exported functions

### DIFF
--- a/Modules/PowerBIPS/PowerBIPS.psd1
+++ b/Modules/PowerBIPS/PowerBIPS.psd1
@@ -62,7 +62,7 @@ FunctionsToExport = @(
 	"Get-PBIAuthToken"
 	, "Set-PBIGroup", "Get-PBIGroup", "Get-PBIGroupUsers", "New-PBIGroup", "New-PBIGroupUser"
 	, "Out-PowerBI"	
-    , "Get-PBIDataSet", "Test-PBIDataSet", "New-PBIDataSet", "Update-PBIDataset", "Get-PBIDatasetRefreshHistory", "Update-PBIDatasetDatasources"
+    , "Get-PBIDataSet", "Test-PBIDataSet", "New-PBIDataSet", "Update-PBIDataset", "Get-PBIDatasetRefreshHistory", "Update-PBIDatasetDatasources", "Get-PBIGroupDatasets"
     , "Get-PBIDatasetParameters", "Set-PBIDatasetParameters"
 	, "Add-PBITableRows", "Clear-PBITableRows", "Update-PBITableSchema"	
 	, "Get-PBIImports", "Import-PBIFile"

--- a/Modules/PowerBIPS/PowerBIPS.psm1
+++ b/Modules/PowerBIPS/PowerBIPS.psm1
@@ -1284,11 +1284,6 @@ Function Import-PBIFile{
 			
     $scope = "imports?datasetDisplayName=$dataSetName&nameConflict=$nameConflict"
 
-	if (-not [string]::IsNullOrEmpty($groupId))
-	{
-        $scope = "groups/$groupId/$scope";
-    }
-			
 	$url = Get-PowerBIRequestUrl -scope $scope -beta
 	
 	$boundary = [System.Guid]::NewGuid().ToString("N")   


### PR DESCRIPTION
```
if (-not [string]::IsNullOrEmpty($groupId))
{
     $scope = "groups/$groupId/$scope"; 
}
```
This logic is already implemented in function _Get-PowerBIRequestUrl_ 
