### PR TITLE
include Get-PBIGroupDatasets in PowerBIPS.psd1 exported functions

### DIFF
--- a/Modules/PowerBIPS/PowerBIPS.psd1
+++ b/Modules/PowerBIPS/PowerBIPS.psd1
@@ -62,7 +62,7 @@ FunctionsToExport = @(
 	"Get-PBIAuthToken"
 	, "Set-PBIGroup", "Get-PBIGroup", "Get-PBIGroupUsers", "New-PBIGroup", "New-PBIGroupUser"
 	, "Out-PowerBI"	
-    , "Get-PBIDataSet", "Get-PBIDataSetTables", "Test-PBIDataSet", "New-PBIDataSet", "Request-PBIDatasetRefresh"
+    , "Get-PBIDataSet", "Get-PBIGroupDatasets", "Get-PBIDataSetTables", "Test-PBIDataSet", "New-PBIDataSet", "Request-PBIDatasetRefresh"
     , "Get-PBIDatasetRefreshHistory", "Update-PBIDatasetDatasources"
     , "Get-PBIDatasetParameters", "Set-PBIDatasetParameters"
 	, "Add-PBITableRows", "Clear-PBITableRows", "Update-PBITableSchema"	


### PR DESCRIPTION
Get-PBIGroupDatasets is not working because is not exported by the module.