### PR TITLE
Update PowerBIPS.Tools.psm1

### DIFF
--- a/Modules/PowerBIPS.Tools/PowerBIPS.Tools.psm1
+++ b/Modules/PowerBIPS.Tools/PowerBIPS.Tools.psm1
@@ -834,7 +834,7 @@ Function Get-CleanMCode{
                 $lastId = $dd[-1].Split('=')
 
                 #Fix the ending
-                if(-Not ($t[0].Contains(" in ") -or $t[0].Contains([Environment]::NewLine+"in"+[Environment]::NewLine)))
+                if(-Not ($t[0] -match '[\s.*]in[\s.*](?=([^"\\]*(\\.|"([^"\\]*\\.)*[^"\\]*"))*[^"]*$)'))
                 { 
                     $t[0] += [Environment]::NewLine + " in " + $lastId[0].Trim()
                 }


### PR DESCRIPTION
Use regex to find the end of a query, based on term 'in' and allow whitespace on either side or line endings but not double quotes in case of strings

issue #51 commit 91151bb