### PR TITLE
Query fix

### DIFF
--- a/Modules/PowerBIPS.Tools/PowerBIPS.Tools.psm1
+++ b/Modules/PowerBIPS.Tools/PowerBIPS.Tools.psm1
@@ -842,7 +842,7 @@ Function Get-CleanMCode{
                 $M = New-Object PSObject -Property @{
                     hiddenTable = $true
                     expression = $t[0]
-                    name = $ex[$i].Split('=')[0]
+                    name = $ex[$i].Split('=')[0].Replace('#"','').Replace('"','')
                 } 
 
                 $colletion += $M


### PR DESCRIPTION
#51 Fixed for cases where referenced table names have spaces. 

Added support for parameter queries.  

Changed table partition expressions to have a simple query referencing the shared expression instead of duplicated the query expression which caused some privacy errors in the mashup engine when processing.